### PR TITLE
Replace the HttpWebRequest by HttpClient

### DIFF
--- a/Aliyun_MQ_SDK/MQClient.cs
+++ b/Aliyun_MQ_SDK/MQClient.cs
@@ -6,17 +6,17 @@ using Aliyun.MQ.Runtime.Internal.Auth;
 
 namespace Aliyun.MQ
 {
-    public partial class MQClient : AliyunServiceClient
+    public partial class MQClient : HttpClientBasedAliyunServiceClient
     {
         #region Constructors
 
-        public MQClient(string accessKeyId, string secretAccessKey, string regionEndpoint)
-            : base(accessKeyId, secretAccessKey, new MQConfig { RegionEndpoint = new Uri(regionEndpoint) }, null)
+        public MQClient(string accessKeyId, string secretAccessKey, string regionEndpoint, int maxErrorRetry = 3)
+            : base(accessKeyId, secretAccessKey, new MQConfig { RegionEndpoint = new Uri(regionEndpoint), MaxErrorRetry = maxErrorRetry}, null)
         {
         }
 
-		public MQClient(string accessKeyId, string secretAccessKey, string regionEndpoint, string stsToken)
-			: base(accessKeyId, secretAccessKey, new MQConfig { RegionEndpoint = new Uri(regionEndpoint) }, stsToken)
+		public MQClient(string accessKeyId, string secretAccessKey, string regionEndpoint, string stsToken, int maxErrorRetry =3)
+			: base(accessKeyId, secretAccessKey, new MQConfig { RegionEndpoint = new Uri(regionEndpoint), MaxErrorRetry = maxErrorRetry}, stsToken)
 		{
 		}
 

--- a/Aliyun_MQ_SDK/MQConsumer.cs
+++ b/Aliyun_MQ_SDK/MQConsumer.cs
@@ -4,6 +4,8 @@ using Aliyun.MQ.Model.Internal.MarshallTransformations;
 using Aliyun.MQ.Runtime;
 using Aliyun.MQ.Util;
 using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
 
 namespace Aliyun.MQ
 {
@@ -13,9 +15,9 @@ namespace Aliyun.MQ
         private string _topicName;
         private string _consumer;
         private string _messageTag;
-        private readonly AliyunServiceClient _serviceClient;
+        private readonly HttpClientBasedAliyunServiceClient _serviceClient;
 
-        public MQConsumer(string instanceId, string topicName, string consumer, string messageTag, AliyunServiceClient serviceClient)
+        public MQConsumer(string instanceId, string topicName, string consumer, string messageTag, HttpClientBasedAliyunServiceClient serviceClient)
         {
             this._instanceId = instanceId;
             this._topicName = topicName;
@@ -77,6 +79,17 @@ namespace Aliyun.MQ
             return _serviceClient.Invoke<AckMessageRequest, AckMessageResponse>(request, marshaller, unmarshaller);
         }
 
+        public async Task<AckMessageResponse> AckMessageAsync(List<string> receiptHandles)
+        {
+            var request = new AckMessageRequest(this._topicName, this._consumer, receiptHandles);
+            request.IntanceId = this._instanceId;
+            var marshaller = new AckMessageRequestMarshaller();
+            var unmarshaller = AckMessageResponseUnmarshaller.Instance;
+
+            var ackMessageResponse = await _serviceClient.InvokeAsync<AckMessageRequest, AckMessageResponse>(request, marshaller, unmarshaller, default(CancellationToken));
+            return ackMessageResponse;
+        }
+
         public List<Message> ConsumeMessage(uint batchSize)
         {
             var request = new ConsumeMessageRequest(this._topicName, this._consumer, this._messageTag);
@@ -90,6 +103,19 @@ namespace Aliyun.MQ
             return result.Messages;
         }
 
+        public async Task<List<Message>> ConsumeMessageAsync(uint batchSize)
+        {
+            var request = new ConsumeMessageRequest(this._topicName, this._consumer, this._messageTag);
+            request.IntanceId = this._instanceId;
+            request.BatchSize = batchSize;
+            var marshaller = ConsumeMessageRequestMarshaller.Instance;
+            var unmarshaller = ConsumeMessageResponseUnmarshaller.Instance;
+
+            var consumeMessageResponse = await _serviceClient.InvokeAsync<ConsumeMessageRequest, ConsumeMessageResponse>(request, marshaller,
+                unmarshaller, default(CancellationToken));
+            return consumeMessageResponse.Messages;
+        }
+
         public List<Message> ConsumeMessageOrderly(uint batchSize)
         {
             var request = new ConsumeMessageRequest(this._topicName, this._consumer, this._messageTag);
@@ -100,8 +126,21 @@ namespace Aliyun.MQ
             var unmarshaller = ConsumeMessageResponseUnmarshaller.Instance;
 
             ConsumeMessageResponse result = _serviceClient.Invoke<ConsumeMessageRequest, ConsumeMessageResponse>(request, marshaller, unmarshaller);
-
             return result.Messages;
+        }
+
+        public async Task<List<Message>> ConsumeMessageOrderlyAsync(uint batchSize)
+        {
+            var request = new ConsumeMessageRequest(this._topicName, this._consumer, this._messageTag);
+            request.IntanceId = this._instanceId;
+            request.BatchSize = batchSize;
+            request.Trasaction = "order";
+            var marshaller = ConsumeMessageRequestMarshaller.Instance;
+            var unmarshaller = ConsumeMessageResponseUnmarshaller.Instance;
+            
+            var consumeMessageResponse = await _serviceClient.InvokeAsync<ConsumeMessageRequest, ConsumeMessageResponse>(request, marshaller,
+                unmarshaller, default(CancellationToken));
+            return consumeMessageResponse.Messages;
         }
 
         public List<Message> ConsumeMessage(uint batchSize, uint waitSeconds)
@@ -118,6 +157,19 @@ namespace Aliyun.MQ
             return result.Messages;
         }
 
+        public async Task<List<Message>> ConsumeMessageAsync(uint batchSize, uint waitSeconds)
+        {
+            var request = new ConsumeMessageRequest(this._topicName, this._consumer, this._messageTag);
+            request.IntanceId = this._instanceId;
+            request.BatchSize = batchSize;
+            request.WaitSeconds = waitSeconds;
+            var marshaller = ConsumeMessageRequestMarshaller.Instance;
+            var unmarshaller = ConsumeMessageResponseUnmarshaller.Instance;
+
+            var consumeMessageResponse = await _serviceClient.InvokeAsync<ConsumeMessageRequest, ConsumeMessageResponse>(request, marshaller, unmarshaller, default(CancellationToken));
+            return consumeMessageResponse.Messages;
+        }
+
         public List<Message> ConsumeMessageOrderly(uint batchSize, uint waitSeconds)
         {
             var request = new ConsumeMessageRequest(this._topicName, this._consumer, this._messageTag);
@@ -131,6 +183,20 @@ namespace Aliyun.MQ
             ConsumeMessageResponse result = _serviceClient.Invoke<ConsumeMessageRequest, ConsumeMessageResponse>(request, marshaller, unmarshaller);
 
             return result.Messages;
+        }
+
+        public async Task<List<Message>> ConsumeMessageOrderlyAsync(uint batchSize, uint waitSeconds)
+        {
+            var request = new ConsumeMessageRequest(this._topicName, this._consumer, this._messageTag);
+            request.IntanceId = this._instanceId;
+            request.BatchSize = batchSize;
+            request.WaitSeconds = waitSeconds;
+            request.Trasaction = "order";
+            var marshaller = ConsumeMessageRequestMarshaller.Instance;
+            var unmarshaller = ConsumeMessageResponseUnmarshaller.Instance;
+
+            var consumeMessageResponse = await _serviceClient.InvokeAsync<ConsumeMessageRequest, ConsumeMessageResponse>(request, marshaller, unmarshaller, default(CancellationToken));
+            return consumeMessageResponse.Messages;
         }
     }
 }

--- a/Aliyun_MQ_SDK/Runtime/HttpClientBasedAliyunServiceClient.cs
+++ b/Aliyun_MQ_SDK/Runtime/HttpClientBasedAliyunServiceClient.cs
@@ -1,0 +1,147 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Net;
+using System.Net.Http;
+using System.Threading;
+using Aliyun.MQ.Runtime.Internal;
+using Aliyun.MQ.Runtime.Internal.Auth;
+using Aliyun.MQ.Runtime.Internal.Transform;
+using Aliyun.MQ.Runtime.Pipeline;
+using Aliyun.MQ.Runtime.Pipeline.ErrorHandler;
+using Aliyun.MQ.Runtime.Pipeline.Handlers;
+using Aliyun.MQ.Runtime.Pipeline.HttpHandler;
+using Aliyun.MQ.Runtime.Pipeline.RetryHandler;
+using ExecutionContext = Aliyun.MQ.Runtime.Internal.ExecutionContext;
+
+namespace Aliyun.MQ.Runtime
+{
+    public abstract class HttpClientBasedAliyunServiceClient : IDisposable
+    {
+        private bool _disposed;
+
+        protected RuntimePipeline RuntimePipeline { get; set; }
+        protected ServiceCredentials Credentials { get; private set; }
+        internal ClientConfig Config { get; private set; }
+
+        internal HttpClientBasedAliyunServiceClient(ServiceCredentials credentials, ClientConfig config)
+        {
+            ServicePointManager.Expect100Continue = true;
+            ServicePointManager.DefaultConnectionLimit = config.ConnectionLimit;
+            ServicePointManager.MaxServicePointIdleTime = config.MaxIdleTime;
+
+            this.Config = config;
+            this.Credentials = credentials;
+            Signer = CreateSigner();
+
+            Initialize();
+
+            BuildRuntimePipeline();
+        }
+
+        protected IServiceSigner Signer { get; private set; }
+
+        protected virtual void Initialize()
+        {
+        }
+
+        protected virtual void CustomizeRuntimePipeline(RuntimePipeline pipeline)
+        {
+        }
+
+        private void BuildRuntimePipeline()
+        {
+            // Replace HttpWebRequestFactory by HttpRequestMessageFactory
+            var httpRequestFactory = new HttpRequestMessageFactory(Config);
+            var httpHandler = new HttpHandler<HttpContent>(httpRequestFactory, this);
+
+            this.RuntimePipeline = new RuntimePipeline(new List<IPipelineHandler>
+                {
+                    httpHandler,
+                    new Unmarshaller(),
+                    new ErrorHandler(),
+                    new Signer(),
+                    new CredentialsRetriever(this.Credentials),
+                    new RetryHandler(new DefaultRetryPolicy(this.Config.MaxErrorRetry)),
+                    new Marshaller()
+                }
+            );
+
+            CustomizeRuntimePipeline(this.RuntimePipeline);
+        }
+
+        internal HttpClientBasedAliyunServiceClient(string accessKeyId, string secretAccessKey, ClientConfig config,
+            string stsToken)
+            : this(new BasicServiceCredentials(accessKeyId, secretAccessKey, stsToken), config)
+        {
+        }
+
+
+        public void Dispose()
+        {
+            Dispose(true);
+            GC.SuppressFinalize(this);
+        }
+
+        protected abstract IServiceSigner CreateSigner();
+
+        protected virtual void Dispose(bool disposing)
+        {
+            return;
+        }
+
+        private void ThrowIfDisposed()
+        {
+            if (this._disposed)
+                throw new ObjectDisposedException(GetType().FullName);
+        }
+
+        internal TResponse Invoke<TRequest, TResponse>(TRequest request,
+            IMarshaller<IRequest, WebServiceRequest> marshaller, ResponseUnmarshaller unmarshaller)
+            where TRequest : WebServiceRequest
+            where TResponse : WebServiceResponse
+        {
+            ThrowIfDisposed();
+
+            var executionContext = new ExecutionContext(
+                new RequestContext()
+                {
+                    ClientConfig = this.Config,
+                    Marshaller = marshaller,
+                    OriginalRequest = request,
+                    Signer = Signer,
+                    Unmarshaller = unmarshaller,
+                    IsAsync = false
+                },
+                new ResponseContext()
+            );
+
+            var response = (TResponse)this.RuntimePipeline.InvokeSync(executionContext).Response;
+            return response;
+        }
+
+        internal System.Threading.Tasks.Task<TResponse> InvokeAsync<TRequest, TResponse>(
+            TRequest request,
+            IMarshaller<IRequest, WebServiceRequest> marshaller,
+            ResponseUnmarshaller unmarshaller,
+            System.Threading.CancellationToken cancellationToken)
+            where TRequest : WebServiceRequest
+            where TResponse : WebServiceResponse, new()
+        {
+            var executionContext = new ExecutionContext(
+                new RequestContext()
+                {
+                    ClientConfig = this.Config,
+                    Marshaller = marshaller,
+                    OriginalRequest = request,
+                    Unmarshaller = unmarshaller,
+                    IsAsync = true,
+                    CancellationToken = cancellationToken,
+                    Signer = Signer,
+                },
+                new ResponseContext()
+            );
+            return this.RuntimePipeline.InvokeAsync<TResponse>(executionContext);
+        }
+    }
+}

--- a/Aliyun_MQ_SDK/Runtime/Internal/Transform/HttpClientResponseData.cs
+++ b/Aliyun_MQ_SDK/Runtime/Internal/Transform/HttpClientResponseData.cs
@@ -1,0 +1,165 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Net;
+using System.Net.Http;
+using System.Net.Http.Headers;
+using System.Threading.Tasks;
+
+namespace Aliyun.MQ.Runtime.Internal.Transform
+{
+    public class HttpClientResponseData : IWebResponseData
+    {
+        HttpResponseMessageBody _response;
+        string[] _headerNames;
+        Dictionary<string, string> _headers;
+        HashSet<string> _headerNamesSet;
+
+        internal HttpClientResponseData(HttpResponseMessage response)
+            : this(response, null, false)
+        {
+        }
+
+        internal HttpClientResponseData(HttpResponseMessage response, HttpClient httpClient, bool disposeClient)
+        {
+            _response = new HttpResponseMessageBody(response, httpClient, disposeClient);
+
+            this.StatusCode = response.StatusCode;
+            this.IsSuccessStatusCode = response.IsSuccessStatusCode;
+            this.ContentLength = response.Content.Headers.ContentLength ?? 0;
+
+            if (response.Content.Headers.ContentType != null)
+            {
+                this.ContentType = response.Content.Headers.ContentType.MediaType;
+            }
+            CopyHeaderValues(response);
+        }
+
+        public HttpStatusCode StatusCode { get; private set; }
+
+        public bool IsSuccessStatusCode { get; private set; }
+
+        public string ContentType { get; private set; }
+
+        public long ContentLength { get; private set; }
+
+        public string GetHeaderValue(string headerName)
+        {
+            string headerValue;
+            if(_headers.TryGetValue(headerName, out headerValue))
+                return headerValue;
+
+            return string.Empty;
+        }
+
+        public bool IsHeaderPresent(string headerName)
+        {
+            return _headerNamesSet.Contains(headerName);
+        }
+
+        public string[] GetHeaderNames()
+        {
+            return _headerNames;
+        }
+
+        private void CopyHeaderValues(HttpResponseMessage response)
+        {
+            List<string> headerNames = new List<string>();
+            _headers = new Dictionary<string, string>(10, StringComparer.OrdinalIgnoreCase);
+
+            foreach (KeyValuePair<string, IEnumerable<string>> kvp in response.Headers)
+            {
+                headerNames.Add(kvp.Key);
+                var headerValue = GetFirstHeaderValue(response.Headers, kvp.Key);
+                _headers.Add(kvp.Key, headerValue);
+            }
+
+            if (response.Content != null)
+            {
+                foreach (var kvp in response.Content.Headers)
+                {
+                    if (!headerNames.Contains(kvp.Key))
+                    {
+                        headerNames.Add(kvp.Key);
+                        var headerValue = GetFirstHeaderValue(response.Content.Headers, kvp.Key);
+                        _headers.Add(kvp.Key, headerValue);
+                    }
+                }
+            }
+            _headerNames = headerNames.ToArray();
+            _headerNamesSet = new HashSet<string>(_headerNames, StringComparer.OrdinalIgnoreCase);
+        }
+
+        private string GetFirstHeaderValue(HttpHeaders headers, string key)
+        {
+            IEnumerable<string> headerValues = null;
+            if (headers.TryGetValues(key, out headerValues))
+                return headerValues.FirstOrDefault();
+
+            return string.Empty;
+        }
+
+        public IHttpResponseBody ResponseBody
+        {
+            get { return _response; }
+        }
+    }
+    
+    [CLSCompliant(false)]
+    public class HttpResponseMessageBody : IHttpResponseBody
+    {
+        HttpClient _httpClient;
+        HttpResponseMessage _response;
+        bool _disposeClient = false;
+        bool _disposed = false;
+
+        public HttpResponseMessageBody(HttpResponseMessage response, HttpClient httpClient, bool disposeClient)
+        {
+            _httpClient = httpClient;
+            _response = response;
+            _disposeClient = disposeClient;
+        }
+
+        public Stream OpenResponse()
+        {
+            if (_disposed)
+                throw new ObjectDisposedException("HttpWebResponseBody");
+
+            return _response.Content.ReadAsStreamAsync().Result;
+        }
+
+        public Task<Stream> OpenResponseAsync()
+        {
+            if (_disposed)
+                throw new ObjectDisposedException("HttpWebResponseBody");
+
+            return _response.Content.ReadAsStreamAsync();
+        }
+
+        public void Dispose()
+        {
+            Dispose(true);
+            GC.SuppressFinalize(this);
+        }
+
+        protected virtual void Dispose(bool disposing)
+        {
+            if (_disposed)
+                return;
+
+            if (disposing)
+            {
+                if (_response != null)
+                    _response.Dispose();
+
+                if (_httpClient != null && _disposeClient)
+                    _httpClient.Dispose();
+
+                _disposed = true;
+            }
+        }
+
+        
+    }
+}

--- a/Aliyun_MQ_SDK/Runtime/Internal/Transform/HttpWebRequestResponseData.cs
+++ b/Aliyun_MQ_SDK/Runtime/Internal/Transform/HttpWebRequestResponseData.cs
@@ -84,6 +84,13 @@ namespace Aliyun.MQ.Runtime.Internal.Transform
             
             return _response.GetResponseStream();
         }
+        
+        public System.Threading.Tasks.Task<Stream> OpenResponseAsync()
+        {
+            // There is no GetResponseStreamAsync on HttpWebResponse so just
+            // reuse the sync version.
+            return System.Threading.Tasks.Task.FromResult(OpenResponse());
+        }
 
         public void Dispose()
         {

--- a/Aliyun_MQ_SDK/Runtime/Internal/Transform/IWebResponseData.cs
+++ b/Aliyun_MQ_SDK/Runtime/Internal/Transform/IWebResponseData.cs
@@ -20,5 +20,7 @@ namespace Aliyun.MQ.Runtime.Internal.Transform
     public interface IHttpResponseBody : IDisposable
     {
         Stream OpenResponse();
+        
+        System.Threading.Tasks.Task<Stream> OpenResponseAsync();
     }
 }

--- a/Aliyun_MQ_SDK/Runtime/Internal/WebServiceRequest.cs
+++ b/Aliyun_MQ_SDK/Runtime/Internal/WebServiceRequest.cs
@@ -82,9 +82,18 @@ namespace Aliyun.MQ.Runtime.Internal
             }
         }
 
-        internal virtual bool Expect100Continue
+        /// <summary>
+        /// Gets or Sets a value indicating if "Expect: 100-continue" HTTP header will be 
+        /// sent by the client for this request. The default value is false.
+        /// </summary>
+        protected virtual bool Expect100Continue
         {
-            get { return true; }            
+            get { return false; }
+        }
+
+        internal bool GetExpect100Continue()
+        {
+            return this.Expect100Continue;
         }
 
         internal virtual bool KeepAlive

--- a/Aliyun_MQ_SDK/Runtime/Pipeline/Contexts.cs
+++ b/Aliyun_MQ_SDK/Runtime/Pipeline/Contexts.cs
@@ -15,6 +15,8 @@ namespace Aliyun.MQ.Runtime.Pipeline
         IServiceSigner Signer { get; }
         ClientConfig ClientConfig { get; }
         ImmutableCredentials ImmutableCredentials { get; set; }
+        
+        System.Threading.CancellationToken CancellationToken { get; }
 
         IRequest Request { get; set; }
         bool IsSigned { get; set; }
@@ -68,6 +70,8 @@ namespace Aliyun.MQ.Runtime.Internal
         public int Retries { get; set; }
         public bool IsSigned { get; set; }
         public bool IsAsync { get; set; }
+
+        public System.Threading.CancellationToken CancellationToken { get; set; }
         public WebServiceRequest OriginalRequest { get; set; }
         public IMarshaller<IRequest, WebServiceRequest> Marshaller { get; set; }
         public ResponseUnmarshaller Unmarshaller { get; set; }

--- a/Aliyun_MQ_SDK/Runtime/Pipeline/Handlers/GenericHandler.cs
+++ b/Aliyun_MQ_SDK/Runtime/Pipeline/Handlers/GenericHandler.cs
@@ -23,6 +23,12 @@ namespace Aliyun.MQ.Runtime.Pipeline.Handlers
             PostInvoke(ExecutionContext.CreateFromAsyncContext(executionContext));
             base.InvokeAsyncCallback(executionContext);           
         }
+        
+        public override System.Threading.Tasks.Task<T> InvokeAsync<T>(IExecutionContext executionContext)
+        {
+            PreInvoke(executionContext);
+            return base.InvokeAsync<T>(executionContext);
+        }
 
         protected virtual void PreInvoke(IExecutionContext executionContext) { }
 

--- a/Aliyun_MQ_SDK/Runtime/Pipeline/HttpHandler/HttpRequestMessageFactory.cs
+++ b/Aliyun_MQ_SDK/Runtime/Pipeline/HttpHandler/HttpRequestMessageFactory.cs
@@ -1,0 +1,528 @@
+using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.IO;
+using System.Net;
+using System.Net.Http;
+using System.Net.Http.Headers;
+using System.Text;
+using System.Threading;
+using Aliyun.MQ.Runtime.Internal.Transform;
+using Aliyun.MQ.Util;
+using NLog;
+
+namespace Aliyun.MQ.Runtime.Pipeline.HttpHandler
+{
+    
+        [CLSCompliant(false)]
+    public abstract class HttpClientFactory
+    {
+        /// <summary>
+        /// Create and configure an HttpClient.
+        /// </summary>
+        /// <returns></returns>
+        public abstract HttpClient CreateHttpClient(ClientConfig clientConfig);
+
+        /// <summary>
+        /// If true the SDK will internally cache the clients created by CreateHttpClient.
+        /// If false the sdk will not cache the clients.
+        /// Override this method to return false if your HttpClientFactory will handle its own caching
+        /// or if you don't want clients to be cached.
+        /// </summary>
+        /// <param name="clientConfig"></param>
+        /// <returns></returns>
+        public virtual bool UseSDKHttpClientCaching(ClientConfig clientConfig)
+        {
+            return clientConfig.CacheHttpClient;
+        }
+
+        /// <summary>
+        /// Determines if the SDK will dispose clients after they're used.
+        /// If HttpClients are cached, either by the SDK or by your HttpClientFactory, this should be false.
+        /// If there is no caching then this should be true.
+        /// </summary>
+        /// <param name="clientConfig"></param>
+        /// <returns></returns>
+        public virtual bool DisposeHttpClientsAfterUse(ClientConfig clientConfig)
+        {
+            return !UseSDKHttpClientCaching(clientConfig);
+        }
+
+        /// <summary>
+        /// Returns a string that's used to group equivalent HttpClients into caches.
+        /// This method isn't used unless UseSDKHttpClientCaching returns true;
+        /// 
+        /// A null return value signals the SDK caching mechanism to cache HttpClients per SDK client.
+        /// So when the SDK client is disposed, the HttpClients are as well.
+        /// 
+        /// A non-null return value signals the SDK that HttpClients created with the given clientConfig
+        /// should be cached and reused globally.  ClientConfigs that produce the same result for
+        /// GetConfigUniqueString will be grouped together and considered equivalent for caching purposes.
+        /// </summary>
+        /// <param name="clientConfig"></param>
+        /// <returns></returns>
+        public virtual string GetConfigUniqueString(ClientConfig clientConfig)
+        {
+            return null;
+        }
+    }
+    
+    public class HttpRequestMessageFactory : IHttpRequestFactory<HttpContent>
+    {
+        private static readonly Logger Logger = MqLogManager.Instance.GetCurrentClassLogger();
+        // This is the global cache of HttpClient for service clients that are using 
+        static readonly ReaderWriterLockSlim _httpClientCacheRWLock = new ReaderWriterLockSlim();
+        static readonly IDictionary<string, HttpClientCache> _httpClientCaches = new Dictionary<string, HttpClientCache>();
+
+        
+        private HttpClientCache _httpClientCache;
+        private bool _useGlobalHttpClientCache;
+        private ClientConfig _clientConfig;
+        
+        /// <summary>
+        /// The constructor for HttpRequestMessageFactory.
+        /// </summary>
+        /// <param name="clientConfig">Configuration setting for a client.</param>
+        public HttpRequestMessageFactory(ClientConfig clientConfig)
+        {
+            _clientConfig = clientConfig;
+        }
+
+        public IHttpRequest<HttpContent> CreateHttpRequest(Uri requestUri)
+        {
+            HttpClient httpClient = null;
+            if (ClientConfig.CacheHttpClients(_clientConfig))
+            {
+                if (_httpClientCache == null)
+                {
+                    _useGlobalHttpClientCache = false;
+
+                    _httpClientCacheRWLock.EnterWriteLock();
+                    try
+                    {
+                        if (_httpClientCache == null)
+                        {
+                            _httpClientCache = CreateHttpClientCache(_clientConfig);
+                        }
+                    }
+                    finally
+                    {
+                        _httpClientCacheRWLock.ExitWriteLock();
+                    }
+                }
+
+                // Now that we have a HttpClientCache from either the global cache or just created a new HttpClientCache
+                // get the next HttpClient to be used for making a web request.
+                httpClient = _httpClientCache.GetNextClient();
+            }
+            else
+            {
+                httpClient = CreateHttpClient(_clientConfig);
+            }
+
+            return new HttpWebRequestMessage(httpClient, requestUri, _clientConfig);
+        }
+
+        public void Dispose()
+        {
+            // Dispose(true);
+            // GC.SuppressFinalize(this);
+        }
+        
+        private static HttpClientCache CreateHttpClientCache(ClientConfig clientConfig)
+        {
+            var clients = new HttpClient[clientConfig.HttpClientCacheSize];
+            for(int i = 0; i < clients.Length; i++)
+            {
+                clients[i] = CreateHttpClient(clientConfig);
+            }
+            var cache = new HttpClientCache(clients);
+            return cache;
+        }
+        
+        private static HttpClient CreateHttpClient(ClientConfig clientConfig)
+        {
+            if (clientConfig.HttpClientFactory == null)
+            {
+                return CreateManagedHttpClient(clientConfig);
+            }
+            else
+            {
+                return clientConfig.HttpClientFactory.CreateHttpClient(clientConfig);
+            }
+        }
+        
+                 /// <summary>
+         /// Create and configure a managed HttpClient instance.
+         /// The use of HttpClientHandler in the constructor for HttpClient implicitly creates a managed HttpClient.
+         /// </summary>
+         /// <param name="clientConfig"></param>
+         /// <returns></returns>
+        private static HttpClient CreateManagedHttpClient(ClientConfig clientConfig)
+        {
+            var httpMessageHandler = new HttpClientHandler();
+
+            if (clientConfig.MaxConnectionsPerServer.HasValue)
+                httpMessageHandler.MaxConnectionsPerServer = clientConfig.MaxConnectionsPerServer.Value;
+
+            try
+            {
+                // If HttpClientHandler.AllowAutoRedirect is set to true (default value),
+                // redirects for GET requests are automatically followed and redirects for POST
+                // requests are thrown back as exceptions.
+                // If HttpClientHandler.AllowAutoRedirect is set to false (e.g. S3),
+                // redirects are returned as responses.
+                httpMessageHandler.AllowAutoRedirect = clientConfig.AllowAutoRedirect;
+
+                // Disable automatic decompression when Content-Encoding header is present
+                httpMessageHandler.AutomaticDecompression = DecompressionMethods.None;
+            }
+            catch (PlatformNotSupportedException pns)
+            {
+                Logger.Debug(pns, $"The current runtime does not support modifying the configuration of HttpClient.");
+            }
+            
+
+            var httpClient = new HttpClient(httpMessageHandler);
+            
+            if (clientConfig.Timeout.HasValue)
+            {
+                // Timeout value is set to ClientConfig.MaxTimeout for S3 and Glacier.
+                // Use default value (100 seconds) for other services.
+                httpClient.Timeout = clientConfig.Timeout.Value;
+            }
+
+            return httpClient;
+        }
+    }
+    
+    /// <summary>
+    /// A cache of HttpClient objects. The GetNextClient method does a round robin cycle through the clients
+    /// to distribute the load even across.
+    /// </summary>
+    public class HttpClientCache : IDisposable
+    {
+        HttpClient[] _clients;
+
+        /// <summary>
+        /// Constructs a container for a cache of HttpClient objects
+        /// </summary>
+        /// <param name="clients">The HttpClient to cache</param>
+        public HttpClientCache(HttpClient[] clients)
+        {
+            _clients = clients;
+        }
+
+        private int count = 0;
+        /// <summary>
+        /// Returns the next HttpClient using a round robin rotation. It is expected that individual clients will be used
+        /// by more then one Thread.
+        /// </summary>
+        /// <returns></returns>
+        public HttpClient GetNextClient()
+        {
+            if (_clients.Length == 1)
+            {
+                return _clients[0];
+            }
+            else
+            {
+                int next = Interlocked.Increment(ref count);
+                int nextIndex = Math.Abs(next % _clients.Length);
+                return _clients[nextIndex];
+            }
+        }
+
+        /// <summary>
+        /// Disposes the HttpClientCache.
+        /// </summary>
+        public void Dispose()
+        {
+            Dispose(true);
+            GC.SuppressFinalize(this);
+        }
+
+        /// <summary>
+        /// Dispose the HttpClientCache
+        /// </summary>
+        /// <param name="disposing"></param>
+        protected virtual void Dispose(bool disposing)
+        {
+            if (disposing)
+            {
+                if (_clients != null)
+                {
+                    foreach (var client in _clients)
+                    {
+                        client.Dispose();
+                    }
+                }
+            }
+        }
+    }
+
+    public class HttpWebRequestMessage : IHttpRequest<HttpContent>
+    {
+        /// <summary>
+        /// Set of content header names.
+        /// </summary>
+        private static HashSet<string> ContentHeaderNames = new HashSet<string>
+        {
+            Constants.ContentLengthHeader,
+            Constants.ContentTypeHeader,
+            Constants.ContentRangeHeader,
+            Constants.ContentMD5Header,
+            Constants.ContentEncodingHeader,
+            Constants.ContentDispositionHeader,
+            Constants.Expires
+        };
+        
+        private bool _disposed;
+        private HttpRequestMessage _request;
+        private HttpClient _httpClient;
+        private ClientConfig _clientConfig;
+        
+        /// <summary>
+        /// The constructor for HttpWebRequestMessage.
+        /// </summary>
+        /// <param name="httpClient">The HttpClient used to make the request.</param>
+        /// <param name="requestUri">The request URI.</param>
+        /// <param name="config">The service client config.</param>
+        public HttpWebRequestMessage(HttpClient httpClient, Uri requestUri, ClientConfig config)
+        {
+            _clientConfig = config;
+            _httpClient = httpClient;
+
+            _request = new HttpRequestMessage();
+            _request.RequestUri = requestUri;
+        }
+
+        /// <summary>
+        /// Disposes the HttpWebRequestMessage.
+        /// </summary>
+        public void Dispose()
+        {
+            Dispose(true);
+            GC.SuppressFinalize(this);
+        }
+
+        /// <summary>
+        /// 
+        /// </summary>
+        /// <param name="disposing"></param>
+        protected virtual void Dispose(bool disposing)
+        {
+            if (_disposed)
+                return;
+
+            if (disposing)
+            {
+                if (_request != null)
+                    _request.Dispose();
+
+                _disposed = true;
+            }
+        }
+
+        /// <summary>
+        /// The HTTP method or verb.
+        /// </summary>
+        public string Method
+        {
+            get { return _request.Method.Method; }
+            set { _request.Method = new System.Net.Http.HttpMethod(value); }
+        }
+        
+        /// <summary>
+        /// The request URI.
+        /// </summary>
+        public Uri RequestUri
+        {
+            get { return _request.RequestUri; }
+        }
+        
+        public void ConfigureRequest(IRequestContext requestContext)
+        {
+            // Configure the Expect 100-continue header
+            if (requestContext != null && requestContext.OriginalRequest != null)
+            {
+                _request.Headers.ExpectContinue = requestContext.OriginalRequest.GetExpect100Continue();
+            }
+        }
+
+        public void SetRequestHeaders(IDictionary<string, string> headers)
+        {
+            foreach (var kvp in headers)
+            {
+                if (ContentHeaderNames.Contains(kvp.Key))
+                    continue;
+                // if (ContentHeaderNames.Contains(kvp.Key, StringComparer.OrdinalIgnoreCase))
+                //     continue;
+                _request.Headers.TryAddWithoutValidation(kvp.Key, kvp.Value);
+            }
+            // TODO
+            _request.Headers.Add("Connection", "Keep-Alive");
+        }
+
+        public HttpContent GetRequestContent()
+        {
+            try
+            {
+                return this.GetRequestContentAsync().Result;
+            }
+            catch (AggregateException e)
+            {
+                throw e.InnerException;
+            }
+        }
+        
+        /// <summary>
+        /// Gets a handle to the request content.
+        /// </summary>
+        /// <returns></returns>
+        public System.Threading.Tasks.Task<HttpContent> GetRequestContentAsync()
+        {
+            return System.Threading.Tasks.Task.FromResult(_request.Content);
+        }
+        
+                /// <summary>
+        /// Returns the HTTP response.
+        /// </summary>
+        /// <param name="cancellationToken">A cancellation token that can be used to cancel the asynchronous operation.</param>
+        /// <returns></returns>
+        public async System.Threading.Tasks.Task<IWebResponseData> GetResponseAsync(System.Threading.CancellationToken cancellationToken)
+        {
+            try
+            {
+                var responseMessage = await _httpClient.SendAsync(_request, HttpCompletionOption.ResponseHeadersRead, cancellationToken)
+                    .ConfigureAwait(continueOnCapturedContext: false);
+
+                bool disposeClient = ClientConfig.DisposeHttpClients(_clientConfig);
+                // If AllowAutoRedirect is set to false, HTTP 3xx responses are returned back as response.
+                if (!_clientConfig.AllowAutoRedirect &&
+                    responseMessage.StatusCode >= HttpStatusCode.Ambiguous &&
+                    responseMessage.StatusCode < HttpStatusCode.BadRequest)
+                {
+                    return new HttpClientResponseData(responseMessage, _httpClient, disposeClient);
+                }
+
+                if (!responseMessage.IsSuccessStatusCode)
+                {
+                    // For all responses other than HTTP 2xx, return an exception.
+                    throw new HttpErrorResponseException(
+                        new HttpClientResponseData(responseMessage, _httpClient, disposeClient));
+                }
+
+                return new HttpClientResponseData(responseMessage, _httpClient, disposeClient);
+            }
+            catch (HttpRequestException httpException)
+            {
+                if (httpException.InnerException != null)
+                {
+                    if (httpException.InnerException is IOException)
+                    {
+                        throw httpException.InnerException;
+                    }
+                }
+
+                throw;
+            }
+            catch (OperationCanceledException canceledException)
+            {
+                if (!cancellationToken.IsCancellationRequested)
+                {
+                    //OperationCanceledException thrown by HttpClient not the CancellationToken supplied by the user.
+                    //This exception can wrap at least IOExceptions, ObjectDisposedExceptions and should be retried.
+                    //Throw the underlying exception if it exists.
+                    if(canceledException.InnerException != null)
+                    {
+                        throw canceledException.InnerException;
+                    }
+                }
+
+                throw;
+            }
+        }
+
+        public IWebResponseData GetResponse()
+        {
+            try
+            {
+                return this.GetResponseAsync(System.Threading.CancellationToken.None).Result;
+            }
+            catch (AggregateException e)
+            {
+                throw e.InnerException;
+            }
+        }
+
+        public void WriteToRequestBody(HttpContent requestContent, Stream contentStream, IDictionary<string, string> contentHeaders,
+            IRequestContext requestContext)
+        {
+            _request.Content = new StreamContent(contentStream, requestContext.ClientConfig.BufferSize);
+            _request.Content.Headers.ContentLength = contentStream.Length;
+            WriteContentHeaders(contentHeaders);
+        }
+
+        public void WriteToRequestBody(HttpContent requestContent, byte[] content, IDictionary<string, string> contentHeaders)
+        {
+            content ??= Encoding.UTF8.GetBytes("a");
+            _request.Content = new ByteArrayContent(content);
+            _request.Content.Headers.ContentLength = content.Length;
+            WriteContentHeaders(contentHeaders);
+        }
+        
+        
+        private void WriteContentHeaders(IDictionary<string, string> contentHeaders)
+        {
+            _request.Content.Headers.ContentType =
+                MediaTypeHeaderValue.Parse(contentHeaders[Constants.ContentTypeHeader]);
+
+            if (contentHeaders.ContainsKey(Constants.ContentRangeHeader))
+                _request.Content.Headers.TryAddWithoutValidation(Constants.ContentRangeHeader,
+                    contentHeaders[Constants.ContentRangeHeader]);
+
+            if (contentHeaders.ContainsKey(Constants.ContentMD5Header))
+                _request.Content.Headers.TryAddWithoutValidation(Constants.ContentMD5Header,
+                    contentHeaders[Constants.ContentMD5Header]);
+
+            if (contentHeaders.ContainsKey(Constants.ContentEncodingHeader))
+                _request.Content.Headers.TryAddWithoutValidation(Constants.ContentEncodingHeader,
+                    contentHeaders[Constants.ContentEncodingHeader]);
+
+            if (contentHeaders.ContainsKey(Constants.ContentDispositionHeader))
+                _request.Content.Headers.TryAddWithoutValidation(Constants.ContentDispositionHeader,
+                    contentHeaders[Constants.ContentDispositionHeader]);
+
+            DateTime expires;
+            if (contentHeaders.ContainsKey(Constants.Expires) &&
+                DateTime.TryParse(contentHeaders[Constants.Expires], CultureInfo.InvariantCulture, DateTimeStyles.None, out expires))
+                _request.Content.Headers.Expires = expires;
+        }
+
+        public void Abort()
+        {
+            throw new NotImplementedException();
+        }
+
+        public IAsyncResult BeginGetRequestContent(AsyncCallback callback, object state)
+        {
+            throw new NotImplementedException();
+        }
+
+        public HttpContent EndGetRequestContent(IAsyncResult asyncResult)
+        {
+            throw new NotImplementedException();
+        }
+
+        public IAsyncResult BeginGetResponse(AsyncCallback callback, object state)
+        {
+            throw new NotImplementedException();
+        }
+
+        public IWebResponseData EndGetResponse(IAsyncResult asyncResult)
+        {
+            throw new NotImplementedException();
+        }
+    }
+}

--- a/Aliyun_MQ_SDK/Runtime/Pipeline/HttpHandler/HttpRequestMessageFactory.cs
+++ b/Aliyun_MQ_SDK/Runtime/Pipeline/HttpHandler/HttpRequestMessageFactory.cs
@@ -466,7 +466,11 @@ namespace Aliyun.MQ.Runtime.Pipeline.HttpHandler
 
         public void WriteToRequestBody(HttpContent requestContent, byte[] content, IDictionary<string, string> contentHeaders)
         {
-            content ??= Encoding.UTF8.GetBytes("a");
+            if (null == content)
+            {
+                content = Encoding.UTF8.GetBytes("a");
+            }
+
             _request.Content = new ByteArrayContent(content);
             _request.Content.Headers.ContentLength = content.Length;
             WriteContentHeaders(contentHeaders);

--- a/Aliyun_MQ_SDK/Runtime/Pipeline/HttpHandler/IHttpRequestFactory.cs
+++ b/Aliyun_MQ_SDK/Runtime/Pipeline/HttpHandler/IHttpRequestFactory.cs
@@ -110,5 +110,19 @@ namespace Aliyun.MQ.Runtime.Pipeline.HttpHandler
         /// <param name="asyncResult">IAsyncResult that represents an async operation.</param>
         /// <returns>The HTTP response.</returns>
         IWebResponseData EndGetResponse(IAsyncResult asyncResult);
+        
+        /// <summary>
+        /// Gets a handle to the request content.
+        /// </summary>
+        /// <returns></returns>
+
+        System.Threading.Tasks.Task<TRequestContent> GetRequestContentAsync();
+        
+        /// <summary>
+        /// Returns the HTTP response.
+        /// </summary>
+        /// <param name="cancellationToken">A cancellation token that can be used to cancel the asynchronous operation.</param>
+        /// <returns></returns>
+        System.Threading.Tasks.Task<IWebResponseData> GetResponseAsync(System.Threading.CancellationToken cancellationToken);
     }
 }

--- a/Aliyun_MQ_SDK/Runtime/Pipeline/IPiplelineHandler.cs
+++ b/Aliyun_MQ_SDK/Runtime/Pipeline/IPiplelineHandler.cs
@@ -50,5 +50,17 @@ namespace Aliyun.MQ.Runtime.Pipeline
         /// <param name="executionContext">The execution context, it contains the
         /// request and response context.</param>
         void AsyncCallback(IAsyncExecutionContext executionContext);
+        
+        /// <summary>
+        /// Contains the processing logic for an asynchronous request invocation.
+        /// This method should call InnerHandler.InvokeSync to continue processing of the
+        /// request by the pipeline, unless it's a terminating handler.
+        /// </summary>
+        /// <typeparam name="T">The response type for the current request.</typeparam>
+        /// <param name="executionContext">The execution context, it contains the
+        /// request and response context.</param>
+        /// <returns>A task that represents the asynchronous operation.</returns>
+        System.Threading.Tasks.Task<T> InvokeAsync<T>(IExecutionContext executionContext)
+            where T : WebServiceResponse, new();
     }
 }

--- a/Aliyun_MQ_SDK/Runtime/Pipeline/PipelineHandler.cs
+++ b/Aliyun_MQ_SDK/Runtime/Pipeline/PipelineHandler.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Threading.Tasks;
 using Aliyun.MQ.Runtime.Internal;
 using Aliyun.MQ.Runtime.Internal.Util;
 
@@ -25,6 +26,16 @@ namespace Aliyun.MQ.Runtime.Pipeline
             if (this.InnerHandler != null)
             {
                 return InnerHandler.InvokeAsync(executionContext);
+            }
+            throw new InvalidOperationException("Cannot invoke InnerHandler. InnerHandler is not set.");
+        }
+        
+        public virtual Task<T> InvokeAsync<T>(IExecutionContext executionContext)
+            where T : WebServiceResponse, new()
+        {
+            if (this.InnerHandler != null)
+            {
+                return InnerHandler.InvokeAsync<T>(executionContext);    
             }
             throw new InvalidOperationException("Cannot invoke InnerHandler. InnerHandler is not set.");
         }

--- a/Aliyun_MQ_SDK/Runtime/Pipeline/RetryHandler/DefaultRetryPolicy.cs
+++ b/Aliyun_MQ_SDK/Runtime/Pipeline/RetryHandler/DefaultRetryPolicy.cs
@@ -4,11 +4,14 @@ using System.IO;
 using System.Net;
 using System.Threading;
 using Aliyun.MQ.Util;
+using NLog;
 
 namespace Aliyun.MQ.Runtime.Pipeline.RetryHandler
 {
     public class DefaultRetryPolicy : RetryPolicy
     {
+        private static readonly Logger Logger = MqLogManager.Instance.GetCurrentClassLogger();
+
         private int _maxBackoffInMilliseconds = (int)TimeSpan.FromSeconds(30).TotalMilliseconds;
 
         // Set of web exception status codes to retry on.
@@ -128,6 +131,7 @@ namespace Aliyun.MQ.Runtime.Pipeline.RetryHandler
         {
             int delay = (int)(Math.Pow(4, retries) * 100);
             delay = Math.Min(delay, maxBackoffInMilliseconds);
+            Logger.Info($"retries={retries}, delay={delay}");
             AliyunSDKUtils.Sleep(delay);
         }
 

--- a/Aliyun_MQ_SDK/Runtime/Pipeline/RuntimePipeline.cs
+++ b/Aliyun_MQ_SDK/Runtime/Pipeline/RuntimePipeline.cs
@@ -66,6 +66,19 @@ namespace Aliyun.MQ.Runtime.Pipeline
 
             return _handler.InvokeAsync(executionContext);
         }
+        
+        /// <summary>
+        /// Invokes the pipeline asynchronously.
+        /// </summary>
+        /// <param name="executionContext">Request context</param>
+        /// <returns>Response context</returns>
+        public System.Threading.Tasks.Task<T> InvokeAsync<T>(IExecutionContext executionContext)
+            where T : WebServiceResponse, new()
+        {
+            ThrowIfDisposed();
+
+            return _handler.InvokeAsync<T>(executionContext);
+        }
 
         #endregion
 

--- a/Aliyun_MQ_SDK/Util/Constants.cs
+++ b/Aliyun_MQ_SDK/Util/Constants.cs
@@ -46,6 +46,10 @@ namespace Aliyun.MQ.Util
 
 
         public const string ContentTypeTextXml = "text/xml";
+        public const string ContentRangeHeader = "Content-Range";
+        public const string ContentEncodingHeader = "Content-Encoding";
+        public const string ContentDispositionHeader = "Content-Disposition";
+        public const string Expires = "Expires";
 
         public const string ContentTypeHeader = "Content-Type";
         public const string ContentLengthHeader = "Content-Length";


### PR DESCRIPTION
Replace the HttpWebRequest by HttpClient since [HttpWebRequest is not recommended by Microsoft](https://learn.microsoft.com/en-us/dotnet/api/system.net.httpwebrequest?view=net-7.0#:~:text=We%20don%27t%20recommend%20that%20you%20use%20HttpWebRequest%20for%20new%20development.%20Instead%2C%20use%20the%20System.Net.Http.HttpClient%20class.).